### PR TITLE
docs: fix edit file links

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -9,7 +9,7 @@ module.exports = {
   themeConfig: {
     repo: 'Akryum/peeky',
     docsDir: 'docs',
-    docsBranch: 'main',
+    docsBranch: 'master',
     editLinks: true,
     editLinkText: 'Suggest changes to this page',
     logo: 'logo.svg',


### PR DESCRIPTION
The "Suggest changes to this page" links for editing document files do not work because they are pointing to the `main` branch which does not exist. Replaced with `master`.